### PR TITLE
Fix typo in project name from 'quickdraws' to 'quickdraw'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# quickdraws!
+# quickdraw!


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the project name in the README heading from 'quickdraws!' to 'quickdraw!'.